### PR TITLE
CMake Fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,16 +1,16 @@
 cmake_minimum_required(VERSION 3.0)
 project(ihs_boost)
 
-option("with_documentation" OFF)
-if (with_documentation)
+option(with_documentation "with_documentation" OFF)
+if (${with_documentation})
     find_package(Doxygen REQUIRED)
 
     set(DOXYGEN_USE_MDFILE_AS_MAINPAGE README.md)
     doxygen_add_docs(doxygen ${CMAKE_SOURCE_DIR} ALL)
 endif()
 
-option("build_library" ON)
-if (build_library)
+option(build_library "build_library" ON)
+if (${build_library})
     add_compile_options("-std=c++17")  # if 17 is not available, 11 will do for everything except for threading test
     add_compile_options("-fPIC")
 

--- a/util/include/accumulator.hpp
+++ b/util/include/accumulator.hpp
@@ -1,7 +1,7 @@
 /**
  * @file accumulator.hpp
- * @author your name (you@domain.com)
- * @brief
+ * @author Eliot Hall
+ * @brief Accumulator class for integrating values
  * @version 0.1
  * @date 2023-02-14
  *


### PR DESCRIPTION
- fix undocumented accumulator.hpp file
- fix cmake problem where cmake default args weren't working