### PR TITLE
sharedptr compatibility patch

### DIFF
--- a/util/src/config.cpp
+++ b/util/src/config.cpp
@@ -149,10 +149,14 @@ private:
     Config *extra_config; ///< the extra config
 };
 
-std::shared_ptr<PartialConfig> ihsboost_config(make_shared<PartialConfig>());
+std::shared_ptr<PartialConfig> ihsboost_config(nullptr);
 
 Config &get_config(std::string config_file)
 {
+    if (ihsboost_config.get() == nullptr)
+    {
+        ihsboost_config = make_shared<PartialConfig>();
+    }
     return *ihsboost_config.get();
 }
 


### PR DESCRIPTION
on older computers, got a segmentation fault from the shared_ptr initialization, so moved shared_ptr initialization for ihsboost_config to inside get_config.