### PR TITLE
Thread refactor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.0)
-project(ihs_boost VERSION 1.6.1)
+project(ihs_boost VERSION 1.7.0)
 
 # options
 option(build_tests "build_tests" OFF)

--- a/modules/threading/include/threadable.hpp
+++ b/modules/threading/include/threadable.hpp
@@ -42,7 +42,7 @@ public:
      * @param func the member function to call. In most circumstances, this is `&CLASS_NAME::METHOD_NAME`
      * where CLASS_NAME is the name of the class and METHOD_NAME is the name of the method
      * @param c a pointer to the instance from which to run the member function.
-     * @param args the arguments with which to call the member function. Note that these should be lvalues
+     * @param args the arguments with which to call the member function. Note that these can be lvalues or rvalues
      */
     template <typename _MemberFunc, typename _Class, typename... _Args,
               typename std::enable_if<std::is_member_function_pointer<_MemberFunc>::value, bool>::type = true>
@@ -58,7 +58,7 @@ public:
      * @tparam _Callable the type of the function to call
      * @tparam _Args the types of the arguments to pass to the thread
      * @param func the function to run
-     * @param args the arguments to pass to the function
+     * @param args the arguments to pass to the function. Note that these can be lvalues or rvalues
      */
     template <typename _Callable, typename... _Args>
     Threadable(_Callable &&func, _Args &&...args) : _started(false), _done(false),

--- a/modules/threading/include/threadable.hpp
+++ b/modules/threading/include/threadable.hpp
@@ -15,7 +15,6 @@
 
 #include <thread>
 #include <type_traits>
-#include <functional>
 #include <tuple>
 
 /**
@@ -116,6 +115,13 @@ public:
     bool started() const;
 
     Threadable &operator=(const Threadable &other) = delete;
+    /**
+     * @brief Equals operator for setting a Threadable equal to
+     * a Threadable rvalue
+     *
+     * @param other the Threadable to set this equal to
+     * @return Threadable& this Threadable
+     */
     Threadable &operator=(Threadable &&other);
 
 private:

--- a/tests/threading/test/thread_test.cpp
+++ b/tests/threading/test/thread_test.cpp
@@ -4,7 +4,6 @@
 #include <chrono>
 #include <thread>
 #include <numeric>
-#include <mutex>
 #include <vector>
 
 using namespace std;
@@ -15,10 +14,10 @@ class Test
 public:
     Test(int val) : val(val){};
     void increment_val(int increment_amt) { val += increment_amt; }
+    void add_vals(int a, int b) { val += a + b; }
     int get_val() { return val; }
 
 private:
-    mutex m;
     int val;
 };
 
@@ -242,6 +241,32 @@ void test_member_func()
     cout << "passed member funcs" << endl;
 }
 
+void test_rvalue_member()
+{
+    Test test(0);
+    Threadable t1(&Test::increment_val, &test, 10);
+    t1.start();
+
+    while (!t1.done())
+        ;
+
+    assert_equals(10, test.get_val(), "testing rvalues member");
+    cout << "passed rvalue member" << endl;
+}
+
+void test_rvalue_static()
+{
+    Test test(0);
+    Threadable t1(a, test, 35);
+    t1.start();
+
+    while (!t1.done())
+        ;
+
+    assert_equals(35, test.get_val(), "testing rvalues static");
+    cout << "passed rvalue static" << endl;
+}
+
 int main()
 {
     test_single_thread_ptr();
@@ -255,6 +280,8 @@ int main()
 
     test_dynamic(rand() % 10, rand() % 50);
     test_member_func();
+    test_rvalue_member();
+    test_rvalue_static();
 
     return 0;
 }

--- a/tests/threading/test/thread_test.cpp
+++ b/tests/threading/test/thread_test.cpp
@@ -224,6 +224,24 @@ void test_dynamic(int val1, int val2)
     cout << "passed test dynamic" << endl;
 }
 
+void test_member_func()
+{
+    Test test(0);
+    int amt1 = 10;
+    int amt2 = 20;
+    Threadable t1(&Test::increment_val, &test, amt1);
+    Threadable t2(&Test::increment_val, &test, amt2);
+
+    t1.start();
+    t2.start();
+
+    while (!t1.done() || !t2.done())
+        ;
+
+    assert_equals(amt1 + amt2, test.get_val(), "testing members");
+    cout << "passed member funcs" << endl;
+}
+
 int main()
 {
     test_single_thread_ptr();
@@ -236,6 +254,7 @@ int main()
     test_multiple_threads();
 
     test_dynamic(rand() % 10, rand() % 50);
+    test_member_func();
 
     return 0;
 }

--- a/tests/threading/test/thread_test.cpp
+++ b/tests/threading/test/thread_test.cpp
@@ -267,6 +267,21 @@ void test_rvalue_static()
     cout << "passed rvalue static" << endl;
 }
 
+void test_multiple_same_type()
+{
+    Test test(0);
+    Threadable t1(&Test::add_vals, &test, 30, 70);
+    Threadable t2(&Test::add_vals, &test, 50, 10);
+    t1.start();
+    t2.start();
+
+    while (!t1.done() || !t2.done())
+        ;
+
+    assert_equals(160, test.get_val(), "testing multiple rvalues of same type");
+    cout << "passed multiple rvalue same type" << endl;
+}
+
 int main()
 {
     test_single_thread_ptr();
@@ -282,6 +297,7 @@ int main()
     test_member_func();
     test_rvalue_member();
     test_rvalue_static();
+    test_multiple_same_type();
 
     return 0;
 }


### PR DESCRIPTION
Use polymorphic wrappers instead of lambdas in order to capture both lvalues and rvalues in the thread
* added base class FunctionWrapper
* added subclass StaticFunctionWrapper for static functions
* added subclass MemberFunctionWrapper for member functions to be called by a pointer to an instance