### PR TITLE
Debian Package Dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.0)
-project(ihs_boost VERSION 1.8.2)
+project(ihs_boost VERSION 1.8.3)
 
 # options
 option(build_tests "build_tests" OFF)
@@ -33,9 +33,10 @@ if(${build_debian})
     # generate debian package
     set(CPACK_GENERATOR "DEB")
 
-    # set maintainer
+    # set debian variables
     set(CPACK_DEBIAN_PACKAGE_MAINTAINER "Eliot")
-    
+    set(CPACK_DEBIAN_PACKAGE_DEPENDS "libjsoncpp-dev, libbluetooth-dev")
+
     # install on target machine to the provided install path
     set(CPACK_PACKAGE_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX})
     

--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ set(CMAKE_SYSROOT /path/to/your/sysroot)
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O3 --target=${CMAKE_SYSTEM_PROCESSOR}-linux-gnu --sysroot=${CMAKE_SYSROOT} -mcpu=cortex-a53")
 set(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS}")
 
+# when building a debian package, make sure to set this variable
+# to the output of `dpkg --print-architecture` on the target machine
+set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE arm64)
+
 # where you want to install the files locally before copying
 # them to their final destination
 set(CMAKE_STAGING_PREFIX /path/to/temporary/out)


### PR DESCRIPTION
* specify dependencies needed for ihsboost to function as a debian package
* edit readme to clarify crosscompiling of debian package